### PR TITLE
Format docstrings for API ref

### DIFF
--- a/kin/account.py
+++ b/kin/account.py
@@ -66,11 +66,12 @@ class KinAccount:
 
     def get_balance(self):
         """
-        Get the KIN balance of this KinAccount
+        Get the Kin balance of this KinAccount
+
         :return: the kin balance
         :rtype: float
 
-        :raises: KinErrors.AccountNotFoundError if the account does not exist.
+        :raises KinErrors.AccountNotFoundError: if the account does not exist.
         """
         return self._client.get_account_balance(self.keypair.public_address)
 
@@ -79,18 +80,19 @@ class KinAccount:
         Gets this KinAccount's data
 
         :return: account data
-        :rtype: kin.blockchain.horizon_models.AccountData
+        :rtype: :class:`kin.blockchain.horizon_models.AccountData`
 
-        :raises: KinErrors.AccountNotFoundError if the account does not exist.
+        :raises KinErrors.AccountNotFoundError: if the account does not exist.
         """
         return self._client.get_account_data(self.keypair.public_address)
 
     def get_status(self, verbose=False):
         """
         Get the config and status of this KinAccount object
+
         :param bool verbose: Should the channels status be verbose
         :return: The config and status of this KinAccount object
-        :rtype dict
+        :rtype: dict
         """
         account_status = {
             'app_id': self.app_id,
@@ -108,6 +110,7 @@ class KinAccount:
     def get_transaction_history(self, amount=10, descending=True, cursor=None, simple=True):
         """
         Get the transaction history for this kin account
+
         :param int amount: The maximum number of transactions to get
         :param bool descending: The order of the transactions, True will start from the latest one
         :param int cursor: The horizon paging token
@@ -125,8 +128,9 @@ class KinAccount:
     def get_transaction_builder(self, fee):
         """
         Get a transaction builder using this account
+
         :param int fee: The fee that will be used for the transaction
-        :return: kin.Builder
+        :return: :class:`kin.Builder`
         """
         return Builder(self._client.environment.name, self.horizon, fee, self.keypair.secret_seed)
 
@@ -135,7 +139,7 @@ class KinAccount:
 
         :param str address: the address of the account to create.
 
-        :param float|str starting_balance: the starting KIN balance of the account.
+        :param float|str starting_balance: the starting Kin balance of the account.
 
         :param str memo_text: (optional) a text to put into transaction memo, up to MEMO_CAP chars.
 
@@ -144,11 +148,11 @@ class KinAccount:
         :return: the hash of the transaction
         :rtype: str
 
-        :raises: KinErrors.StellarAddressInvalidError: if the provided address has a wrong format.
-        :raises: KinErrors.AccountExistsError if the account already exists.
-        :raises: KinErrors.NotValidParamError if the memo is longer than MEMO_CAP characters
-        :raises: KinErrors.NotValidParamError: if the amount is too precise
-        :raises: KinErrors.NotValidParamError: if the fee is not valid
+        :raises KinErrors.StellarAddressInvalidError: if the provided address has a wrong format.
+        :raises KinErrors.AccountExistsError: if the account already exists.
+        :raises KinErrors.NotValidParamError: if the memo is longer than MEMO_CAP characters
+        :raises KinErrors.NotValidParamError: if the amount is too precise
+        :raises KinErrors.NotValidParamError: if the fee is not valid
         """
         builder = self.build_create_account(address, starting_balance, fee, memo_text)
 
@@ -161,11 +165,11 @@ class KinAccount:
             return self.submit_transaction(builder)
 
     def send_kin(self, address, amount, fee, memo_text=None):
-        """Send KIN to the account identified by the provided address.
+        """Send Kin to the account identified by the provided address.
 
-        :param str address: the account to send KIN to.
+        :param str address: the account to send Kin to.
 
-        :param float|str amount: the amount of KIN to send.
+        :param float|str amount: the amount of Kin to send.
 
         :param str memo_text: (optional) a text to put into transaction memo.
 
@@ -174,13 +178,13 @@ class KinAccount:
         :return: the hash of the transaction
         :rtype: str
 
-        :raises: KinErrors.StellarAddressInvalidError: if the provided address has a wrong format.
-        :raises: ValueError: if the amount is not positive.
-        :raises: KinErrors.NotValidParamError: if the amount is too precise
-        :raises: KinErrors.AccountNotFoundError if the account does not exist.
-        :raises: KinErrors.LowBalanceError if there is not enough KIN to send and pay transaction fee.
-        :raises: KinErrors.NotValidParamError if the memo is longer than MEMO_CAP characters
-        :raises: KinErrors.NotValidParamError: if the fee is not valid
+        :raises KinErrors.StellarAddressInvalidError: if the provided address has a wrong format.
+        :raises ValueError: if the amount is not positive.
+        :raises KinErrors.NotValidParamError: if the amount is too precise
+        :raises KinErrors.AccountNotFoundError: if the account does not exist.
+        :raises KinErrors.LowBalanceError: if there is not enough Kin to send and pay transaction fee.
+        :raises KinErrors.NotValidParamError: if the memo is longer than MEMO_CAP characters
+        :raises KinErrors.NotValidParamError: if the fee is not valid
         """
         builder = self.build_send_kin(address, amount, fee, memo_text)
         with self.channel_manager.get_channel() as channel:
@@ -196,16 +200,16 @@ class KinAccount:
 
         :param str address: the address of the account to create.
 
-        :param float|str starting_balance: the starting XLM balance of the account.
+        :param float|str starting_balance: the starting Kin balance of the account.
 
         :param str memo_text: (optional) a text to put into transaction memo, up to MEMO_CAP chars.
 
         :param int fee: fee to be deducted for the tx
 
         :return: a transaction builder object
-        :rtype: kin.Builder
+        :rtype: :class:`kin.Builder`
 
-        :raises: KinErrors.StellarAddressInvalidError: if the supplied address has a wrong format.
+        :raises KinErrors.StellarAddressInvalidError: if the supplied address has a wrong format.
         """
         if not is_valid_address(address):
             raise KinErrors.StellarAddressInvalidError('invalid address: {}'.format(address))
@@ -220,21 +224,21 @@ class KinAccount:
         return builder
 
     def build_send_kin(self, address, amount, fee, memo_text=None):
-        """Build a tx to send KIN to the account identified by the provided address.
+        """Build a tx to send Kin to the account identified by the provided address.
 
         :param str address: the account to send asset to.
 
-        :param float|str amount: the KIN amount to send.
+        :param float|str amount: the Kin amount to send.
 
         :param str memo_text: (optional) a text to put into transaction memo.
 
         :param int fee: fee to be deducted for the tx
 
         :return: a transaction builder
-        :rtype: kin.Builder
+        :rtype: :class:`kin.Builder`
 
-        :raises: KinErrors.StellarAddressInvalidError: if the provided address has a wrong format.
-        :raises: ValueError: if the amount is not positive.
+        :raises KinErrors.StellarAddressInvalidError: if the provided address has a wrong format.
+        :raises ValueError: if the amount is not positive.
         """
 
         if not is_valid_address(address):
@@ -251,13 +255,14 @@ class KinAccount:
     def submit_transaction(self, tx_builder):
         """
         Submit a transaction to the blockchain.
+
         :param kin.Builder tx_builder: The transaction builder
         :return: The hash of the transaction.
         :rtype: str
         """
         try:
             return tx_builder.submit()['hash']
-        # If the channel is out of KIN, top it up and try again
+        # If the channel is out of Kin, top it up and try again
         except HorizonError as e:
             logger.warning('send transaction error with channel {}: {}'.format(tx_builder.address, str(e)))
             if e.type == HorizonErrorType.TRANSACTION_FAILED \
@@ -274,23 +279,25 @@ class KinAccount:
                 raise KinErrors.translate_error(e)
 
     def monitor_payments(self, callback_fn):
-        """Monitor KIN payment transactions related to this account
-        NOTE: the function starts a background thread.
+        """Monitor Kin payment transactions related to this account
+
+        **Note:**  The function starts a background thread.
 
         :param callback_fn: the function to call on each received payment as `callback_fn(address, tx_data, monitor)`.
-        :type: callable[str,kin.transactions.SimplifiedTransaction,kin.monitors.SingleMonitor]
+        :type: callable[str, :class:`kin.transactions.SimplifiedTransaction` , :class:`kin.monitors.SingleMonitor` ]
 
         :return: a monitor instance
-        :rtype: kin.monitors.SingleMonitor
+        :rtype: :class:`kin.monitors.SingleMonitor`
         """
         return self._client.monitor_account_payments(self.keypair.public_address, callback_fn)
 
     def whitelist_transaction(self, payload):
         """
         Sign on a transaction to whitelist it
+
         :param str payload: the json received from the client
         :return: a signed transaction encoded as base64
-        :rtype str
+        :rtype: str
         """
 
         # load the object from the json
@@ -327,6 +334,7 @@ class KinAccount:
     def _top_up(self, address):
         """
         Top up a channel with the base account.
+
         :param str address: The address to top up
         """
         # In theory, if the sdk runs in threads, and 2 or more channels

--- a/kin/blockchain/builder.py
+++ b/kin/blockchain/builder.py
@@ -15,6 +15,7 @@ class Builder(BaseBuilder):
     def __init__(self, network_name, horizon, fee, secret):
         """
         Create a new transaction builder
+
         :param str network_name: The name of the network
         :param kin.Horizon horizon: The horizon instance to use
         :param int fee: Fee for the transaction
@@ -31,7 +32,7 @@ class Builder(BaseBuilder):
         self.horizon = horizon
 
     def clear(self):
-        """"Clears the builder so it can be reused."""
+        """Clears the builder so it can be reused."""
         self.ops = []
         self.time_bounds = None
         self.memo = NoneMemo()
@@ -60,6 +61,7 @@ class Builder(BaseBuilder):
     def set_channel(self, channel_seed):
         """
         Set a channel to be used for this transaction
+
         :param str channel_seed: Seed to use as the channel
         """
         self.keypair = Keypair.from_seed(channel_seed)

--- a/kin/blockchain/channel_manager.py
+++ b/kin/blockchain/channel_manager.py
@@ -22,6 +22,7 @@ class ChannelManager:
     def __init__(self, channel_seeds):
         """
         Crete a channel manager instance
+
         :param list[str] channel_seeds: The seeds of the channels to use
         """
         self.channel_pool = ChannelPool(channel_seeds)
@@ -30,11 +31,12 @@ class ChannelManager:
     def get_channel(self, timeout=CHANNEL_GET_TIMEOUT):
         """
         Get an available channel
-        :param float timeout: (Optional) How long to wait before raising an exception
-        :return a free channel seed
-        :rtype str
 
-        :raises KinErrors.ChannelBusyError
+        :param float timeout: (Optional) How long to wait before raising an exception
+        :return: a free channel seed
+        :rtype: str
+
+        :raises KinErrors.ChannelBusyError:
         """
         try:
             channel = self.channel_pool.get(timeout=timeout)
@@ -50,10 +52,11 @@ class ChannelManager:
     def put_channel(self, channel, timeout=CHANNEL_PUT_TIMEOUT):
         """
         Set a channel status back to FREE
+
         :param str channel: the channel to set back to FREE
         :param float timeout: (Optional) How long to wait before raising an exception
 
-        :raises KinErrors.ChannelsFullError
+        :raises KinErrors.ChannelsFullError: if the queue is full
         """
         try:
             self.channel_pool.put(channel, timeout=timeout)
@@ -63,9 +66,10 @@ class ChannelManager:
     def get_status(self, verbose=False):
         """
         Return the current status of the channel manager
+
         :param bool verbose: Include all channel seeds and their statuses in the response
         :return: The status of the channel manager
-        :rtype dict
+        :rtype: dict
         """
         free_channels = len(self.channel_pool.get_free_channels())
         status = {
@@ -96,6 +100,7 @@ class ChannelPool(queue.Queue, object):
     def __init__(self, channels_seeds):
         """
         Create an instance of ChannelPool
+
         :param list[str] channels_seeds: The seeds to be put in the queue
         """
         # Init base queue
@@ -106,8 +111,9 @@ class ChannelPool(queue.Queue, object):
     def _get(self):
         """
         Randomly get an available free channel from the dict
+
         :return: a channel seed
-        :rtype str
+        :rtype: str
         """
         # Get a list of all free channels
         free_channels = self.get_free_channels()
@@ -120,6 +126,7 @@ class ChannelPool(queue.Queue, object):
     def _put(self, channel):
         """
         Change a channel status back to FREE
+
         :param str channel: the channel seed
         """
         # Change channel state to free
@@ -128,8 +135,9 @@ class ChannelPool(queue.Queue, object):
     def _qsize(self):
         """
         Used to determine if the queue is empty
+
         :return: amount of free channels in the queue
-        :rtype int
+        :rtype: int
         """
         # Base queue checks if the queue is not empty by checking the length of the queue (_qsize() != 0)
         # We need to check it by checking how many channels are free
@@ -138,7 +146,7 @@ class ChannelPool(queue.Queue, object):
     def get_free_channels(self):
         """
         Get a list of channels with "FREE" status
-        :rtype list[str]
+
+        :rtype: list[str]
         """
         return [channel for channel, status in self.queue.items() if status == ChannelStatuses.FREE]
-

--- a/kin/blockchain/errors.py
+++ b/kin/blockchain/errors.py
@@ -1,4 +1,4 @@
-"""Contains errors types related to horizon"""
+"""Contains error types related to horizon"""
 
 from .horizon_models import HTTPProblemDetails
 
@@ -15,28 +15,29 @@ HORIZON_NS_PREFIX = 'https://stellar.org/horizon-errors/'
 """
 Horizon error example:
 
-{
-    'status': 400,
-    'title': 'Transaction Failed',
-    'detail': 'The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this '
-              'response contains further details.  Descriptions of each code can be found at: '
-              'https://www.stellar.org/developers/learn/concepts/list-of-operations.html',
-    'instance': '903d29404b0e/DAurVuBoL4-004368',
-    'extras': 	{
-        'result_codes': {
-            'operations': ['op_no_destination'],
-            'transaction': 'tx_failed'
-        }, 
-        'envelope_xdr': u'AAAAAJgXswhWU+pdHmHIurQuHk4ziNlKFxEJltbMOpF6EqETAAAAZAAAed0AAAAQAAAAAAAAAAAAAAABAAAAAAAAA'
-                        u'AEAAAAAxbIcFBPzPZbzjWdkSB5FCSIva+WdQ2Oi70GUmFvFmOcAAAABVEVTVAAAAAD284i665ald1Kiq064FGlL+'
-                        u'Aeych/b9UQngBHR37ZeiwAAAAAF9eEAAAAAAAAAAAF6EqETAAAAQN5x3xaOaeDS5EF3tE0X9zXymhqkOg95Tyfgu'
-                        u'//TCbv9XN49CHoH5K+BUH04o1ZAZdHbnBABxh44bu7zbFLgQQU=',
-        'invalid_field': None,
-        'result_xdr': u'AAAAAAAAAGT/////AAAAAQAAAAAAAAAB////+wAAAAA='
-    },
-    'type': 'https://stellar.org/horizon-errors/transaction_failed'
-}
+.. code-block:: json
 
+    {
+        'status': 400,
+        'title': 'Transaction Failed',
+        'detail': 'The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this '
+                  'response contains further details.  Descriptions of each code can be found at: '
+                  'https://www.stellar.org/developers/learn/concepts/list-of-operations.html',
+        'instance': '903d29404b0e/DAurVuBoL4-004368',
+        'extras': 	{
+            'result_codes': {
+                'operations': ['op_no_destination'],
+                'transaction': 'tx_failed'
+            },
+            'envelope_xdr': u'AAAAAJgXswhWU+pdHmHIurQuHk4ziNlKFxEJltbMOpF6EqETAAAAZAAAed0AAAAQAAAAAAAAAAAAAAABAAAAAAAAA'
+                            u'AEAAAAAxbIcFBPzPZbzjWdkSB5FCSIva+WdQ2Oi70GUmFvFmOcAAAABVEVTVAAAAAD284i665ald1Kiq064FGlL+'
+                            u'Aeych/b9UQngBHR37ZeiwAAAAAF9eEAAAAAAAAAAAF6EqETAAAAQN5x3xaOaeDS5EF3tE0X9zXymhqkOg95Tyfgu'
+                            u'//TCbv9XN49CHoH5K+BUH04o1ZAZdHbnBABxh44bu7zbFLgQQU=',
+            'invalid_field': None,
+            'result_xdr': u'AAAAAAAAAGT/////AAAAAQAAAAAAAAAB////+wAAAAA='
+        },
+        'type': 'https://stellar.org/horizon-errors/transaction_failed'
+    }
 """
 
 

--- a/kin/blockchain/keypair.py
+++ b/kin/blockchain/keypair.py
@@ -14,7 +14,8 @@ class Keypair:
 
     def __init__(self, seed=None):
         """
-        # Create an instance of Keypair.
+        Create an instance of Keypair.
+
         :param str seed: (Optional) The secret seed of an account
         """
         self.secret_seed = seed or self.generate_seed()
@@ -30,9 +31,10 @@ class Keypair:
     def sign(self, data):
         """
         Sign any data using the keypair's private key
+
         :param bytes data: any data to sign
         :return: a decorated signature
-        :rtype kin_base.stellarxdr.StellarXDR_type.DecoratedSignature
+        :rtype: kin_base.stellarxdr.StellarXDR_type.DecoratedSignature
         """
         signature = self._signing_key.sign(data)
         return DecoratedSignature(self._hint, signature)
@@ -41,9 +43,10 @@ class Keypair:
     def address_from_seed(seed):
         """
         Get a public address from a secret seed.
+
         :param str seed: The secret seed of an account.
         :return: A public address.
-        :rtype str
+        :rtype: str
         """
         return BaseKeypair.from_seed(seed).address().decode()
 
@@ -51,8 +54,9 @@ class Keypair:
     def generate_seed():
         """
         Generate a random secret seed.
+
         :return: A secret seed.
-        :rtype str
+        :rtype: str
         """
         return BaseKeypair.random().seed().decode()
 
@@ -60,10 +64,11 @@ class Keypair:
     def generate_hd_seed(base_seed, salt):
         """
         Generate a highly deterministic seed from a base seed + salt
+
         :param str base_seed: The base seed to generate a seed from
         :param str salt: A unique string that will be used to generate the seed
         :return: a new seed.
-        :rtype str
+        :rtype: str
         """
         # Create a new raw seed from this hash
         raw_seed = sha256((base_seed + salt).encode()).digest()

--- a/kin/client.py
+++ b/kin/client.py
@@ -19,16 +19,17 @@ logger = logging.getLogger(__name__)
 
 class KinClient(object):
     """
-    The :class:`kin.KinClient` class is the primary interface to the KIN Python SDK based on Kin Blockchain.
+    The :class:`kin.KinClient` class is the primary interface to the Kin Python SDK based on Kin Blockchain.
     It maintains a connection context with a Horizon node and hides all the specifics of dealing with Kin REST API.
     """
 
     def __init__(self, environment):
-        """Create a new instance of the KinClient to query the Kin blockchain.
+        """Create a new instance of the KinClient to query the Kin Blockchain.
+
         :param kin.Environment environment: an environment for the client to point to.
 
         :return: An instance of the KinClient.
-        :rtype: KinErrors.KinClient
+        :rtype: :class:`KinErrors.KinClient`
         """
 
         self.environment = environment
@@ -40,13 +41,14 @@ class KinClient(object):
     def kin_account(self, seed, channel_secret_keys=None, app_id=ANON_APP_ID):
         """
         Create a new instance of a KinAccount to perform authenticated operations on the blockchain.
+
         :param str seed: The secret seed of the account that will be used
         :param list[str] channel_secret_keys: A list of seeds to be used as channels
         :param str app_id: the unique id of your app
         :return: An instance of KinAccount
-        :rtype: kin.KinAccount
+        :rtype: :class:`kin.KinAccount`
 
-        :raises: KinErrors.AccountNotFoundError if SDK wallet or channel account is not yet created.
+        :raises KinErrors.AccountNotFoundError: if SDK wallet or channel account is not yet created.
         """
 
         # Create a new kin account, using self as the KinClient to be used
@@ -54,6 +56,7 @@ class KinClient(object):
 
     def get_config(self):
         """Get system configuration data and online status.
+
         :return: a dictionary containing the data
         :rtype: dict
         """
@@ -86,6 +89,7 @@ class KinClient(object):
     def get_minimum_fee(self):
         """
         Get the current minimum fee acceptable for a tx
+
         :return: The minimum fee
         :type: int
         """
@@ -95,13 +99,14 @@ class KinClient(object):
 
     def get_account_balance(self, address):
         """
-        Get the KIN balance of a given account
+        Get the Kin balance of a given account
+
         :param str address: the public address of the account to query
         :return: the balance of the account
         :rtype: float
 
-        :raises: StellarAddressInvalidError: if the provided address has the wrong format.
-        :raises: KinErrors.AccountNotFoundError if the account does not exist.
+        :raises StellarAddressInvalidError: if the provided address has the wrong format.
+        :raises KinErrors.AccountNotFoundError: if the account does not exist.
         """
 
         if not is_valid_address(address):
@@ -115,11 +120,12 @@ class KinClient(object):
     def does_account_exists(self, address):
         """
         Find out if a given account exists on the blockchain
+
         :param str address: The kin account to query about
         :return: does the account exists on the blockchain
-        :rtype boolean
+        :rtype: boolean
 
-        :raises: KinErrors.StellarAddressInvalidError if the address is not valid.
+        :raises KinErrors.StellarAddressInvalidError: if the address is not valid.
         """
 
         if not is_valid_address(address):
@@ -137,10 +143,10 @@ class KinClient(object):
         :param str address: the public address of the account to query.
 
         :return: account data
-        :rtype: kin.blockchain.horizon_models.AccountData
+        :rtype: :class:`kin.blockchain.horizon_models.AccountData`
 
-        :raises: StellarAddressInvalidError: if the provided address has a wrong format.
-        :raises: :class:`KinErrors.AccountNotFoundError`: if the account does not exist.
+        :raises StellarAddressInvalidError: if the provided address has a wrong format.
+        :raises KinErrors.AccountNotFoundError: if the account does not exist.
         """
         # TODO: might want to simplify the returning data
         if not is_valid_address(address):
@@ -161,11 +167,11 @@ class KinClient(object):
         :param boolean simple: (optional) returns a simplified transaction object
 
         :return: transaction data
-        :rtype: kin.transactions.RawTransaction | kin.transactions.SimplifiedTransaction
+        :rtype: :class:`kin.transactions.RawTransaction` | :class:`kin.transactions.SimplifiedTransaction`
 
-        :raises: ValueError: if the provided hash is invalid.
-        :raises: :class:`KinErrors.ResourceNotFoundError`: if the transaction does not exist.
-        :raises: :class:`KinErrors.CantSimplifyError`: if the tx is too complex to simplify
+        :raises ValueError: if the provided hash is invalid.
+        :raises KinErrors.ResourceNotFoundError: if the transaction does not exist.
+        :raises KinErrors.CantSimplifyError: if the tx is too complex to simplify
         """
         # TODO: separate to two methods, get_tx_data & get_raw_tx_data
         if not is_valid_transaction_hash(tx_hash):
@@ -183,13 +189,14 @@ class KinClient(object):
     def get_account_tx_history(self, address, amount=10, descending=True, cursor=None, simple=True):
         """
         Get the transaction history for a given account.
+
         :param str address: The public address of the account to query
         :param int amount: The maximum number of transactions to get
-        :param bool descending: The order of the transactions, True will start from the latest one
+        :param bool descending: The order of the transactions. If True, will start from the latest one
         :param int cursor: The horizon paging token
-        :param bool simple: Should the returned txs be simplified, if True, complicated txs will be ignored
+        :param bool simple: Should the returned txs be simplified. If True, complicated txs will be ignored
         :return: A list of transactions
-        :rtype: list[kin.transactions.RawTransaction | kin.transactions.SimplifiedTransaction]
+        :rtype: list[ :class:`kin.transactions.RawTransaction` | :class:`kin.transactions.SimplifiedTransaction`]
         """
 
         if not is_valid_address(address):
@@ -234,6 +241,7 @@ class KinClient(object):
     def verify_kin_payment(self, tx_hash, source, destination, amount, memo=None, check_memo=False, app_id=ANON_APP_ID):
         """
         Verify that a give tx matches the desired parameters
+
         :param str tx_hash: The hash of the transaction to query
         :param str source: The expected source account
         :param str destination: The expected destination account
@@ -263,15 +271,16 @@ class KinClient(object):
     def friendbot(self, address):
         """
         Use the friendbot service to create and fund an account
+
         :param str address: The address to create and fund
 
         :return: the hash of the friendbot transaction
-        :rtype str
+        :rtype: str
 
         :raises ValueError: if no friendbot service was provided
         :raises ValueError: if the address is invalid
-        :raises KinErrors.AccountExistsError if the account already exists
-        :raises KinErrors.FriendbotError If the friendbot request failed
+        :raises KinErrors.AccountExistsError: if the account already exists
+        :raises KinErrors.FriendbotError: If the friendbot request failed
         """
 
         if self.environment.friendbot_url is None:
@@ -289,39 +298,41 @@ class KinClient(object):
             raise KinErrors.FriendbotError(response.status_code, response.text)
 
     def monitor_account_payments(self, address, callback_fn):
-        """Monitor KIN payment transactions related to the account identified by provided address.
-        NOTE: the function starts a background thread.
+        """Monitor Kin payment transactions related to the account identified by provided address.
+
+        **Note:**  The function starts a background thread.
 
         :param str address: the address of the account to query.
 
         :param callback_fn: the function to call on each received payment as `callback_fn(address, tx_data, monitor)`.
-        :type: callable[str,kin.transactions.SimplifiedTransaction, kin.SingleMonitor]
+        :type: callable[str, :class:`kin.transactions.SimplifiedTransaction`, :class:`kin.monitors.SingleMonitor` ]
 
         :return: a monitor instance
-        :rtype: kin.monitors.SingleMonitor
+        :rtype: :class:`kin.monitors.SingleMonitor`
 
-        :raises: ValueError: when no address is given.
-        :raises: ValueError: if the address is in the wrong format
-        :raises: KinErrors.AccountNotActivatedError if the account given is not activated
+        :raises ValueError: when no address is given.
+        :raises ValueError: if the address is in the wrong format
+        :raises KinErrors.AccountNotActivatedError: if the account given is not activated
         """
 
         return SingleMonitor(self, address, callback_fn)
 
     def monitor_accounts_payments(self, addresses, callback_fn):
-        """Monitor KIN payment transactions related to multiple accounts
-        NOTE: the function starts a background thread.
+        """Monitor Kin payment transactions related to multiple accounts
+
+        **Note:**  The function starts a background thread.
 
         :param str addresses: the addresses of the accounts to query.
 
         :param callback_fn: the function to call on each received payment as `callback_fn(address, tx_data, monitor)`.
-        :type: callable[str,kin.transactions.SimplifiedTransaction ,kin.monitors.MultiMonitor]
+        :type: callable[str, :class:`kin.transactions.SimplifiedTransaction` , :class:`kin.monitors.MultiMonitor` ]
 
         :return: a monitor instance
-        :rtype: kin.monitors.MultiMonitor
+        :rtype: :class:`kin.monitors.MultiMonitor`
 
-        :raises: ValueError: when no address is given.
-        :raises: ValueError: if the addresses are in the wrong format
-        :raises: KinErrors.AccountNotActivatedError if the accounts given are not activated
+        :raises ValueError: when no address is given.
+        :raises ValueError: if the addresses are in the wrong format
+        :raises KinErrors.AccountNotActivatedError: if the accounts given are not activated
         """
 
         return MultiMonitor(self, addresses, callback_fn)

--- a/kin/monitors.py
+++ b/kin/monitors.py
@@ -16,10 +16,11 @@ class SingleMonitor:
     def __init__(self, kin_client, address, callback_fn):
         """
         Monitors a single account for kin payments
+
         :param kin.KinClient kin_client: a kin client directed to the correct network
         :param str address: address to watch
         :param callback_fn: the function to call on each received payment as `callback_fn(address, tx_data, monitor)`.
-        :type: callable[str,kin.transactions.SimplifiedTransaction ,kin.monitors.MultiMonitor]
+        :type: callable[str, :class:`kin.transactions.SimplifiedTransaction` , :class:`kin.monitors.MultiMonitor`]
         """
         self.kin_client = kin_client
         self.callback_fn = callback_fn
@@ -58,6 +59,7 @@ class SingleMonitor:
     def event_processor(self, stop_event):
         """
         Method to filter through SSE events and find kin payments for an account
+
         :param threading.Event stop_event: an event that can be used to stop this method
         """
         import json
@@ -104,15 +106,16 @@ class SingleMonitor:
 
 
 class MultiMonitor:
-    """Multi Monitor to monitor Kin payment on a multiple accounts"""
+    """Multi Monitor to monitor Kin payment on multiple accounts"""
 
     def __init__(self, kin_client, addresses, callback_fn):
         """
         Monitors multiple accounts for kin payments
+
         :param kin.KinClient kin_client: a kin client directed to the correct network
         :param str addresses: addresses to watch
         :param callback_fn: the function to call on each received payment as `callback_fn(address, tx_data, monitor)`.
-        :type: callable[str,kin.transactions.SimplifiedTransaction ,kin.monitors.MultiMonitor]
+        :type: callable[str, :class:`kin.transactions.SimplifiedTransaction` , :class:`kin.monitors.MultiMonitor`]
         """
         self.kin_client = kin_client
         self.callback_fn = callback_fn
@@ -150,6 +153,7 @@ class MultiMonitor:
     def event_processor(self, stop_event):
         """
         Method to filter through SSE events and find kin payments for an account
+
         :param threading.Event stop_event: an event that can be used to stop this method
         """
         import json
@@ -200,6 +204,7 @@ class MultiMonitor:
     def add_address(self, address):
         """
         Add address to the watched addresses list
+
         :param address: address to add
         """
         if address in self.addresses:
@@ -219,6 +224,7 @@ class MultiMonitor:
     def remove_address(self, address):
         """
         Remove an address for the list of addresses to watch
+
         :param address: the address to remove
         """
         if self.stop_event.is_set():

--- a/kin/transactions.py
+++ b/kin/transactions.py
@@ -48,7 +48,7 @@ class SimplifiedOperation:
 
     def __init__(self, op_data):
         if isinstance(op_data, Payment):
-            # Raise error if its not a KIN payment
+            # Raise error if its not a Kin payment
             if op_data.asset.type != NATIVE_ASSET_TYPE:
                 raise CantSimplifyError('Cant simplify operation with asset {} issued by {}'.
                                         format(op_data.asset.code, op_data.asset.issuer))
@@ -87,6 +87,7 @@ class OperationTypes(Enum):
 def build_memo(app_id, memo):
     """
     Build a memo for a tx that fits the pre-defined template
+
     :param str app_id: The app_id to include in the memo
     :param str memo: The memo to include
     :return: the finished memo
@@ -102,12 +103,13 @@ def build_memo(app_id, memo):
 def decode_transaction(b64_tx, network_id, simple=True):
     """
     Decode a base64 transaction envelop
+
     :param str b64_tx: a transaction envelop encoded in base64
     :param boolean simple: should the tx be simplified
     :param str network_id: the network_id for the transaction
     :return: The transaction
-    :rtype kin.transactions.SimplifiedTransaction | kin_base.Transaction
-    :raises: KinErrors.CantSimplifyError: if the tx cannot be simplified
+    :rtype: :class:`kin.transactions.SimplifiedTransaction` | :class:`kin_base.Transaction`
+    :raises KinErrors.CantSimplifyError: if the tx cannot be simplified
     """
     unpacker = Xdr.StellarXDRUnpacker(base64.b64decode(b64_tx))
     envelop = unpacker.unpack_TransactionEnvelope()
@@ -129,12 +131,15 @@ def calculate_tx_hash(tx, network_passphrase_hash):
     Calculate a tx hash.
 
     A tx hash is a sha256 hash of:
+
     1. A sha256 hash of the network_id +
     2. The xdr representation of ENVELOP_TYPE_TX +
     3. The xdr representation of the transaction
+
     :param tx: The builder's transaction object
     :param network_passphrase_hash: The network passphrase hash
-    :return:
+    :return: sha256 hash (hex)
+    :rtype: str
     """
     # Pack the transaction to xdr
     packer = Xdr.StellarXDRPacker()

--- a/kin/utils.py
+++ b/kin/utils.py
@@ -11,13 +11,14 @@ from .errors import AccountNotFoundError
 def create_channels(master_seed, environment, amount, starting_balance, salt):
     """
     Create HD seeds based on a master seed and salt
+
     :param str master_seed: The master seed that creates the seeds
     :param Kin.Environment environment: The blockchain environment to create the seeds on
     :param int amount: Number of seeds to create (Up to 100)
     :param float starting_balance: Starting balance to create channels with
     :param str salt: A string to be used to create the HD seeds
     :return: The list of seeds generated
-    :rtype list[str]
+    :rtype: list[str]
     """
 
     client = KinClient(environment)
@@ -59,11 +60,12 @@ def create_channels(master_seed, environment, amount, starting_balance, salt):
 def get_hd_channels(master_seed, salt, amount):
     """
     Get a list of channels generated based on a seed and salt
+
     :param str master_seed: the base seed that created the channels
     :param str salt: A string to be used to generate the seeds
     :param int amount: Number of seeds to generate (Up to 100)
     :return: The list of seeds generated
-    :rtype list[str]
+    :rtype: list[str]
     """
 
     if amount > 100:
@@ -82,7 +84,3 @@ def get_hd_channels(master_seed, salt, amount):
         channels.append(channel)
 
     return channels
-
-
-
-


### PR DESCRIPTION
Formatted docstrings in Python SDK source files and for re-build of API ref.

The following three edits were made to the content of the docstrings:

* In account.py / monitor_account_payments I changed :rtype: kin.SingleMonitor -> kin.monitors.SingleMonitor
* In transactions.py calculate_tx_hash I clarified :return: sha256 hash (hex)
  :rtype: str
* In channel_manager.py / put_channel I added explanation to  :raises KinErrors.ChannelsFullError: if the queue is full

Everything else was strictly formatting and cross-linking.