### PR TITLE
DP-370 Fix history

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2,7 +2,7 @@ import pytest
 from time import sleep
 
 from kin import KinClient, TEST_ENVIRONMENT, KinErrors
-from kin import config
+from kin import config, client
 
 
 def test_create():
@@ -158,7 +158,7 @@ async def test_friendbot_fund(test_client):
 
 
 @pytest.mark.asyncio
-async def test_tx_history(test_client,test_account):
+async def test_tx_history(test_client, test_account):
     address = 'GA4GDLBEWVT5IZZ6JKR4BF3B6JJX5S6ISFC2QCC7B6ZVZWJDMR77HYP6'
     await test_client.friendbot(address)
     txs = []
@@ -175,12 +175,12 @@ async def test_tx_history(test_client,test_account):
 
     assert txs == history_ids
 
-    # TODO: INCORRECT TESTING, broken
     # test paging
-    config.MAX_RECORDS_PER_REQUEST = 2
+    client.MAX_RECORDS_PER_REQUEST = 4
 
     tx_history = await test_client.get_account_tx_history(test_account.get_public_address(), amount=6)
     history_ids = [tx.id for tx in tx_history]
+    txs.reverse()
 
     assert txs == history_ids
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -171,7 +171,7 @@ async def test_tx_history(test_client, test_account):
 
     history_ids = [tx.id for tx in tx_history]
     # tx history goes from latest to oldest
-    txs.reverse()
+    history_ids.reverse()
 
     assert txs == history_ids
 
@@ -180,7 +180,7 @@ async def test_tx_history(test_client, test_account):
 
     tx_history = await test_client.get_account_tx_history(test_account.get_public_address(), amount=6)
     history_ids = [tx.id for tx in tx_history]
-    txs.reverse()
+    history_ids.reverse()
 
     assert txs == history_ids
 


### PR DESCRIPTION
Fixed paging with txs history, before the fix the "get_tx_history" method returned None if it had to use paging.

Also changed the implementation from recursion to loop